### PR TITLE
Added unist-util-visit to deps

### DIFF
--- a/lib/ast-to-solid.tsx
+++ b/lib/ast-to-solid.tsx
@@ -7,7 +7,7 @@ import type {
   Comment,
   DocType,
 } from "hast";
-import type { Info, Schema } from "property-information";
+import type { Schema } from "property-information";
 import type { NormalComponents, SolidMarkdownProps } from "./complex-types";
 import { Dynamic } from "solid-js/web";
 
@@ -104,7 +104,7 @@ export type Options = {
 import { svg, find, hastToReact } from "property-information";
 import { stringify as spaces } from "space-separated-tokens";
 import { stringify as commas } from "comma-separated-tokens";
-import * as style from "style-to-object";
+import style from "style-to-object";
 import { Component, JSX } from "solid-js";
 
 const own = {}.hasOwnProperty;

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -19,13 +19,13 @@ type LayoutOptions = {
   class: string;
 };
 
-type ReactMarkdownOptions = CoreOptions &
+type SolidMarkdownOptions = CoreOptions &
   PluginOptions &
   LayoutOptions &
   FilterOptions &
   TransformOptions;
 
-const defaults: ReactMarkdownOptions = {
+const defaults: SolidMarkdownOptions = {
   remarkPlugins: [],
   rehypePlugins: [],
   class: "",
@@ -43,8 +43,8 @@ const defaults: ReactMarkdownOptions = {
   linkTarget: "_self",
   components: {},
 };
-const SolidMarkdown: Component<Partial<ReactMarkdownOptions>> = (opts) => {
-  const options: ReactMarkdownOptions = mergeProps(defaults, opts);
+const SolidMarkdown: Component<Partial<SolidMarkdownOptions>> = (opts) => {
+  const options: SolidMarkdownOptions = mergeProps(defaults, opts);
   const processor = unified()
     .use(remarkParse)
     .use(options.remarkPlugins || [])

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "comma-separated-tokens": "^2.0.2",
-        "hast": "^1.0.0",
         "property-information": "^6.0.1",
         "remark-gfm": "^3.0.0",
         "remark-parse": "^10.0.0",
@@ -18,10 +17,12 @@
         "space-separated-tokens": "^2.0.1",
         "style-to-object": "^0.3.0",
         "unified": "^10.1.0",
+        "unist-util-visit": "^4.1.0",
         "vfile": "^5.1.0"
       },
       "devDependencies": {
         "@rollup/plugin-babel": "^5.3.0",
+        "@types/hast": "^2.3.4",
         "rollup": "^2.58.0",
         "rollup-preset-solid": "^1.0.1",
         "typescript": "^4.4.3"
@@ -917,12 +918,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/hast": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hast/-/hast-1.0.0.tgz",
-      "integrity": "sha1-UGFeaysFg+Vgi8dsRwKXIvHgBgc=",
-      "deprecated": "Renamed to rehype"
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
@@ -3060,11 +3055,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "hast": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hast/-/hast-1.0.0.tgz",
-      "integrity": "sha1-UGFeaysFg+Vgi8dsRwKXIvHgBgc="
     },
     "inline-style-parser": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "private": false,
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",
+    "@types/hast": "^2.3.4",
     "rollup": "^2.58.0",
     "rollup-preset-solid": "^1.0.1",
     "typescript": "^4.4.3"
@@ -57,7 +58,6 @@
   },
   "dependencies": {
     "comma-separated-tokens": "^2.0.2",
-    "hast": "^1.0.0",
     "property-information": "^6.0.1",
     "remark-gfm": "^3.0.0",
     "remark-parse": "^10.0.0",
@@ -65,6 +65,7 @@
     "space-separated-tokens": "^2.0.1",
     "style-to-object": "^0.3.0",
     "unified": "^10.1.0",
+    "unist-util-visit": "^4.1.0",
     "vfile": "^5.1.0"
   }
 }


### PR DESCRIPTION
- unist-util-visit was missing from deps, added
- removed hast from dependencies, and added @types/hast instead to
devDependencies
- import default import from style to object to fix vite and vscode
warning
- renamed ReactMarkdownOptions to SolidMarkdownOptions