### PR TITLE
chore(pnpm): update pnpm to v9.15.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,9 +115,9 @@
     "vite-plugin-solid": "^2.7.2",
     "vitest": "^0.33.0"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@9.15.9",
   "engines": {
     "node": ">=18",
-    "pnpm": ">=8.6.0"
+    "pnpm": ">=9.15.9"
   }
 }


### PR DESCRIPTION
Since we have `lockfileVersion: 9.0` in `pnpm-lock.yaml`, thus we should use pnpm v9+ (pnpm v8 or earlier is not compatible for our `pnpm-lock.yaml`)

Here I set `"pacakgeMangaer": "pnpm@9.15.9"` which is the latest version of pnpm v9.
If you prefer pnpm v10, please discard this PR and use that instead.

Thank you,